### PR TITLE
refactor: prevent destroying modal on close

### DIFF
--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -48,9 +48,7 @@ import com.paypal.messages.utils.LogCat
 import java.net.URI
 import java.util.UUID
 import kotlin.system.measureTimeMillis
-import com.google.android.material.R as MaterialR
 import com.paypal.messages.config.PayPalMessageOfferType as OfferType
-
 
 @RequiresApi(Build.VERSION_CODES.M)
 internal class ModalFragment constructor(
@@ -257,7 +255,7 @@ internal class ModalFragment constructor(
 			behavior.isFitToContents = false
 			behavior.expandedOffset = offsetTop
 			behavior.isHideable = true
-			behavior.isDraggable = false
+			behavior.isDraggable = true
 			behavior.state = BottomSheetBehavior.STATE_EXPANDED
 		}
 

--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -2,7 +2,6 @@ package com.paypal.messages
 
 import android.annotation.SuppressLint
 import android.app.Dialog
-import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.PorterDuff
@@ -76,6 +75,7 @@ internal class ModalFragment constructor(
 	private var currentUrl: String? = null
 	private var webView: WebView? = null
 	private var rootView: View? = null
+	private var dialog: BottomSheetDialog? = null
 	private var closeButtonData: ModalCloseButton? = null
 	private var instanceId = UUID.randomUUID()
 
@@ -136,12 +136,12 @@ internal class ModalFragment constructor(
 
 		closeButton?.setOnClickListener {
 			logEvent(TrackingEvent(eventType = EventType.MODAL_CLOSE))
-			this.dismiss()
+			dialog?.hide()
 		}
 
 		// If we already have a WebView, don't reset it
 		LogCat.debug(TAG, "Configuring WebView Settings and Handlers")
-		val webView = rootView.findViewById<WebView>(R.id.ModalWebView)
+		val webView = rootView.findViewById<RoundedWebView>(R.id.ModalWebView)
 
 		// Programmatically set bottom margin instead of in XML since we also apply it to the
 		// dialog behavior below to control it in a single location. The expanded offset below shifts
@@ -250,23 +250,24 @@ internal class ModalFragment constructor(
 	}
 
 	override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-		val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
-		dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
-		dialog.behavior.isFitToContents = false
-		dialog.behavior.expandedOffset = offsetTop
-		dialog.behavior.isHideable = false
-		dialog.behavior.isDraggable = false
-		dialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED
-		dialog.setOnShowListener { setupBottomSheet(it) }
+		setStyle(STYLE_NO_FRAME, R.style.BottomSheetDialog)
+
+		val dialog = (super.onCreateDialog(savedInstanceState) as BottomSheetDialog).apply {
+			window?.setBackgroundDrawableResource(android.R.color.transparent)
+			behavior.isFitToContents = false
+			behavior.expandedOffset = offsetTop
+			behavior.isHideable = true
+			behavior.isDraggable = false
+			behavior.state = BottomSheetBehavior.STATE_EXPANDED
+		}
+
+		this.dialog = dialog
 
 		return dialog
 	}
 
-	private fun setupBottomSheet(dialogInterface: DialogInterface) {
-		val bottomSheetDialog = dialogInterface as BottomSheetDialog
-		val bottomSheet = bottomSheetDialog.findViewById<View>(MaterialR.id.design_bottom_sheet)
-		if (bottomSheet === null) return
-		bottomSheet.setBackgroundColor(Color.TRANSPARENT)
+	fun expand() {
+		this.dialog?.show()
 	}
 
 	fun init(config: ModalConfig) {

--- a/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
+++ b/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
@@ -324,15 +324,9 @@ class PayPalMessageView @JvmOverloads constructor(
 	}
 
 	private fun showWebView(response: ActionResponse) {
-		// Does an instance of the modal exist already?
-		if (modal != null) {
-			modal!!.show((context as AppCompatActivity).supportFragmentManager, modal!!.tag)
-		}
-		else {
-			// if it doesn't, instantiate the modal
-			val modal = ModalFragment(clientId)
-			val fragmentManager = (context as AppCompatActivity).supportFragmentManager
 
+		val modal = modal ?: run {
+			val modal = ModalFragment(clientId)
 			// Build modal config
 			val modalConfig = ModalConfig(
 				amount = amount,
@@ -352,8 +346,23 @@ class PayPalMessageView @JvmOverloads constructor(
 
 			modal.init(modalConfig)
 			modal.show((context as AppCompatActivity).supportFragmentManager, modal.tag)
+
 			this.modal = modal
+
+			modal
 		}
+
+		// modal.show() above will display the modal on initial view, but if the user closes the modal
+		// it will become visually hidden and this method will re-display the modal without
+		// attempting to reattach it
+		modal.expand()
+	}
+
+	override fun onDetachedFromWindow() {
+		super.onDetachedFromWindow()
+		// The modal will not dismiss (destroy) itself, it will only hide/show when opening and closing
+		// so we need to cleanup the modal instance if the message is removed
+		this.modal?.dismiss()
 	}
 
 	fun refresh() {

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<style name="BottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
+		<item name="bottomSheetStyle">@style/BottomSheetModal</item>
+	</style>
+
+	<style name="BottomSheetModal" parent="Widget.Design.BottomSheet.Modal">
+		<item name="android:background">@android:color/transparent</item>
+	</style>
+</resources>


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

- Modal will now reopen using the previous WebView preventing a complete reload of the page
- Moved transparent background styling into style file to follow best practices
- Modal can now be closed by dragging it

## Screenshots

N/A

## Testing instructions

N/A
