### PR TITLE
feat: use nested coroutine to prevent blocking

### DIFF
--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -18,6 +18,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.IOException
 import java.util.UUID
+import kotlin.system.measureTimeMillis
 import com.paypal.messages.config.PayPalEnvironment as Env
 import com.paypal.messages.config.PayPalMessageOfferType as OfferType
 import com.paypal.messages.config.message.PayPalMessageConfig as MessageConfig
@@ -113,7 +114,7 @@ object Api {
 				LocalStorage.State.NO_HASH -> getAndStoreNewHash(context, messageConfig)
 				LocalStorage.State.HASH_OLDER_THAN_HARD_TTL -> getAndStoreNewHash(context, messageConfig)
 				LocalStorage.State.HASH_BETWEEN_SOFT_AND_HARD_TTL -> {
-					getAndStoreNewHash(context, messageConfig)
+					launch { getAndStoreNewHash(context, messageConfig) }
 					merchantHash
 				}
 				LocalStorage.State.HASH_YOUNGER_THAN_SOFT_TTL -> merchantHash

--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -18,7 +18,6 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.IOException
 import java.util.UUID
-import kotlin.system.measureTimeMillis
 import com.paypal.messages.config.PayPalEnvironment as Env
 import com.paypal.messages.config.PayPalMessageOfferType as OfferType
 import com.paypal.messages.config.message.PayPalMessageConfig as MessageConfig


### PR DESCRIPTION
## Description

This moves getAndStoreNewHash into a nested coroutine so it no longer blocks the main thread

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

Since getting the right merchant hash state can be tricky, I suggest forcing it by manually setting `merchantHashState`.

Once it's set, you can measure the duration of the nested coroutine with `measureTimeMillis` like so

```
val merchantHashState = LocalStorage.State.HASH_BETWEEN_SOFT_AND_HARD_TTL

val measuredDuration = measureTimeMillis {
  launch { getAndStoreNewHash(context, messageConfig) }
}
LogCat.debug(TAG, "MEASURED DURATION: $measuredDuration")
```

Tests for the specific state can be found [here in LocalStorageTest](https://github.com/paypal/paypal-messages-android/pull/16/files#diff-a7d63c8d6ebdf983b9689a5dfb0954c7c24074b55f12a0e1132861266fa5c329R47)

And tests for the specific API requests can be found in [ApiTest](https://github.com/paypal/paypal-messages-android/pull/16/files#diff-2eafa446475e821ca792e4ec5658536db0bd73f69bf0d9000bbac13d392c3b2b)

(Replaced by #19 due to conflicts)
