### PR TITLE
feat: update message view to use its own instance id

### DIFF
--- a/library/src/androidTest/java/com/paypal/messages/io/ApiTest.kt
+++ b/library/src/androidTest/java/com/paypal/messages/io/ApiTest.kt
@@ -23,6 +23,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
 import com.paypal.messages.config.message.PayPalMessageConfig as MessageConfig
 
 @RunWith(AndroidJUnit4::class)
@@ -30,6 +31,7 @@ class ApiTest {
 	private lateinit var context: Context
 	private lateinit var sharedPreferences: SharedPreferences
 	private lateinit var mockWebServer: MockWebServer
+	private val instanceId = UUID.randomUUID()
 	private val messageConfig = MessageConfig(
 		data = PayPalMessageData(clientID = "test_client_id"),
 	)
@@ -60,7 +62,7 @@ class ApiTest {
 
 	@Test
 	fun testCreateMessageDataRequestWithNoData() {
-		val messageDataRequest = Api.createMessageDataRequest(messageConfig, null)
+		val messageDataRequest = Api.createMessageDataRequest(messageConfig, null, instanceId)
 		val url = messageDataRequest.url.toString()
 
 		val expectedPath = "credit-presentment/native/message"
@@ -92,7 +94,7 @@ class ApiTest {
 			),
 			style = PayPalMessageStyle(),
 		)
-		val messageDataRequest = Api.createMessageDataRequest(config, "hash")
+		val messageDataRequest = Api.createMessageDataRequest(config, "hash", instanceId)
 		val url = messageDataRequest.url.toString()
 
 		val expectedPath = "credit-presentment/native/message"
@@ -134,7 +136,7 @@ class ApiTest {
 		mockWebServer.enqueue(mockMessageDataResponse)
 
 		launch {
-			val result = Api.callMessageDataEndpoint(messageConfig, null)
+			val result = Api.callMessageDataEndpoint(messageConfig, null, instanceId)
 			assertTrue(result is ApiResult.Failure<*>)
 			val error = (result as ApiResult.Failure<*>).error
 			assertTrue(error is PayPalErrors.FailedToFetchDataException)
@@ -156,7 +158,7 @@ class ApiTest {
 		mockWebServer.enqueue(mockMessageDataResponse)
 
 		launch {
-			val result = Api.callMessageDataEndpoint(messageConfig, null)
+			val result = Api.callMessageDataEndpoint(messageConfig, null, instanceId)
 			assertTrue(result is ApiResult.Failure<*>)
 			val error = (result as ApiResult.Failure<*>).error
 			assertTrue(error is PayPalErrors.InvalidResponseException)
@@ -178,7 +180,7 @@ class ApiTest {
 		mockWebServer.enqueue(mockMessageDataResponse)
 
 		launch {
-			val result = Api.callMessageDataEndpoint(messageConfig, null)
+			val result = Api.callMessageDataEndpoint(messageConfig, null, instanceId)
 			assertTrue(result is ApiResult.Success<*>)
 			val response = (result as ApiResult.Success<*>).response
 			assertTrue(response.toJson().contains("content"))
@@ -213,7 +215,7 @@ class ApiTest {
 		}
 
 		launch {
-			Api.getMessageWithHash(context, messageConfig, onActionCompleted)
+			Api.getMessageWithHash(context, messageConfig, instanceId, onActionCompleted)
 		}.join()
 
 		advanceUntilIdle()

--- a/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
+++ b/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
@@ -59,6 +59,7 @@ class PayPalMessageView @JvmOverloads constructor(
 	private val TAG = "PayPalMessage"
 	private var messageTextView: TextView
 	private var updateInProgress = false
+	private var instanceId = UUID.randomUUID()
 
 	var config: MessageConfig = config.copy()
 		set(configArg) {
@@ -355,8 +356,6 @@ class PayPalMessageView @JvmOverloads constructor(
 	 */
 	private fun updateMessageContent() {
 		if (!updateInProgress) {
-			Api.instanceId = UUID.randomUUID()
-
 			// Call OnLoading callback and prepare view for the process
 			onLoading.invoke()
 			messageTextView.visibility = View.GONE
@@ -367,6 +366,7 @@ class PayPalMessageView @JvmOverloads constructor(
 				Api.getMessageWithHash(
 					context,
 					MessageConfig(data = data, style = style),
+					this.instanceId,
 					this,
 				)
 			}.toInt()
@@ -546,7 +546,7 @@ class PayPalMessageView @JvmOverloads constructor(
 			offerCountryCode = this.messageDataResponse?.meta?.offerCountryCode,
 			merchantCountryCode = this.messageDataResponse?.meta?.merchantCountryCode,
 			type = ComponentType.MESSAGE.toString(),
-			instanceId = Api.instanceId.toString(),
+			instanceId = this.instanceId.toString(),
 			originatingInstanceId = Api.originatingInstanceId.toString(),
 			sessionId = Api.sessionId.toString(),
 			componentEvents = mutableListOf(event),

--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -30,12 +30,15 @@ object Api {
 	var devTouchpoint: Boolean = false
 	var ignoreCache: Boolean = false
 	var stageTag: String? = null
-	var instanceId: UUID? = null
 	var originatingInstanceId: UUID? = null
 	var sessionId: UUID? = null
 	var ioDispatcher = Dispatchers.IO
 
-	private fun HttpUrl.Builder.setMessageDataQuery(config: MessageConfig, hash: String?) {
+	private fun HttpUrl.Builder.setMessageDataQuery(
+		config: MessageConfig,
+		hash: String?,
+		instanceId: UUID,
+	) {
 		addQueryParameter("client_id", config.data.clientID)
 		addQueryParameter("devTouchpoint", devTouchpoint.toString())
 		addQueryParameter("ignore_cache", ignoreCache.toString())
@@ -51,13 +54,17 @@ object Api {
 		hash?.let { addQueryParameter("merchant_config", it) }
 	}
 
-	internal fun createMessageDataRequest(config: MessageConfig, hash: String?): Request {
+	internal fun createMessageDataRequest(
+		config: MessageConfig,
+		hash: String?,
+		instanceId: UUID,
+	): Request {
 		val request = Request.Builder().apply {
 			header("Accept", "application/json")
 			header("x-requested-by", "native-upstream-messages")
 
 			val urlBuilder = env.url(Env.Endpoints.MESSAGE_DATA).newBuilder()
-			urlBuilder.setMessageDataQuery(config, hash)
+			urlBuilder.setMessageDataQuery(config, hash, instanceId)
 			url(urlBuilder.build())
 		}.build()
 
@@ -66,9 +73,13 @@ object Api {
 		return request
 	}
 
-	internal fun callMessageDataEndpoint(config: MessageConfig, hash: String?): ApiResult {
+	internal fun callMessageDataEndpoint(
+		config: MessageConfig,
+		hash: String?,
+		instanceId: UUID,
+	): ApiResult {
 		LogCat.debug(TAG, "callMessageDataEndpoint hash: $hash")
-		val request = createMessageDataRequest(config, hash)
+		val request = createMessageDataRequest(config, hash, instanceId)
 		try {
 			val response = client.newCall(request).execute()
 			val code = response.code
@@ -101,6 +112,7 @@ object Api {
 	fun getMessageWithHash(
 		context: Context,
 		messageConfig: MessageConfig,
+		instanceId: UUID,
 		onCompleted: OnActionCompleted,
 	) {
 		CoroutineScope(ioDispatcher).launch {
@@ -120,7 +132,7 @@ object Api {
 				else -> null
 			}
 
-			val messageData = callMessageDataEndpoint(messageConfig, newHash)
+			val messageData = callMessageDataEndpoint(messageConfig, newHash, instanceId)
 			withContext(Dispatchers.Main) {
 				onCompleted.onActionCompleted(messageData)
 			}


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

Updated the MessageView to use its own UUID for the instanceId. The ModalFragment already had its own UUID so no change was necessary

## Testing instructions

- Create multiple message components
- Check the log event to verify they each have their own instance ID
    - It may be easiest to just add `LogCat.info(TAG, "instanceId: ${this.instanceId}")` to PayPalMessageView.logEvent to clearly see it

(Replaces #18 due to conflicts)
