### PR TITLE
feat: modal updates

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -67,13 +67,11 @@ android {
 
 tasks.register('addPreCommitGitHookOnBuild') {
 	group 'git'
-	if (! project.file('../.git/hooks/pre-commit').exists()) {
-		println("⚈ ⚈ ⚈ Running Add Pre Commit Git Hook Script on Build ⚈ ⚈ ⚈")
-		exec {
-			commandLine("cp", "../scripts/pre-commit", "../.git/hooks")
-		}
-		println("✅ Added Pre Commit Git Hook Script.")
+	println("⚈ ⚈ ⚈ Running Add Pre Commit Git Hook Script on Build ⚈ ⚈ ⚈")
+	exec {
+		commandLine("cp", "../scripts/pre-commit", "../.git/hooks")
 	}
+	println("✅ Added Pre Commit Git Hook Script.")
 }
 
 preBuild.doFirst { addPreCommitGitHookOnBuild }

--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -234,7 +234,7 @@ internal class ModalFragment(
 			behavior.isFitToContents = false
 			behavior.expandedOffset = offsetTop
 			behavior.isHideable = true
-			behavior.isDraggable = true
+			behavior.isDraggable = false
 			behavior.state = BottomSheetBehavior.STATE_EXPANDED
 		}
 

--- a/library/src/main/res/layout/paypal_message_modal_sheet_layout.xml
+++ b/library/src/main/res/layout/paypal_message_modal_sheet_layout.xml
@@ -44,9 +44,9 @@
 		android:layout_width="64dip"
 		android:layout_height="64dip"
 		android:layout_alignParentTop="true"
-		android:layout_alignParentRight="true"
+		android:layout_alignParentEnd="true"
 		android:layout_marginTop="12dip"
-		android:layout_marginRight="12dip"
+		android:layout_marginEnd="12dip"
 		android:background="@drawable/ic_close"
 		android:scaleType="center"
 		android:contentDescription="Close modal" />

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -16,10 +16,14 @@ echo git diff --staged --name-only | grep -E '(library|demo)'
 echo ""
 echo "Running ktFormat to fix any auto-fixable issues"
 
+git stash --quiet --keep-index
+
 ./gradlew ktFormat
 
 git add library/
 git add demo/
+
+git stash pop --quiet
 
 echo "***********************************************"
 echo "Added changed files to commit"


### PR DESCRIPTION
## Description

- Fix warnings in modal layout
- Turned off `isDraggable` so modal scrolls properly
- Verified that the modal updates when the offer/amount updates for the message
- Updated pre-commit hook to not add unstaged files
- Updated pre-commit gradle task to always copy the hook over

## Testing instructions

- Run the demo
- Update the offer to each type, check the modal updates
- Update the amount for each offer, check the modal updates
- Check that the modal scrolls up and down after stopping scroll in the middle