### PR TITLE
fix: add offer type to modal analytics

### DIFF
--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -444,6 +444,7 @@ internal class ModalFragment(
 			type = ComponentType.MODAL.toString(),
 			instanceId = this.instanceId.toString(),
 			componentEvents = mutableListOf(event),
+			offerType = this.offerType,
 			__shared__ = dynamicKeys,
 		)
 


### PR DESCRIPTION
## Description

Add offer type to modal analytics

## Testing instructions

Check that the modal offer type shows up in analytics
