### PR TITLE
fix: add integration type to requests

### DIFF
--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -42,6 +42,7 @@ object Api {
 		instanceId: UUID,
 	) {
 		addQueryParameter("client_id", config.data.clientID)
+		addQueryParameter("integration_type", BuildConfig.INTEGRATION_TYPE)
 		if (devTouchpoint) addQueryParameter("dev_touchpoint", "true")
 		if (ignoreCache) addQueryParameter("ignore_cache", "true")
 		addQueryParameter("instance_id", instanceId.toString())


### PR DESCRIPTION

## Description

Adds integration type to message requests

## Testing instructions

Run a couple message requests and make sure `integration_type=NATIVE_ANDROID` is in the request
