### PR TITLE
fix: apk install failed during test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,14 @@ jobs:
       - name: Run Instrumentation Tests
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
-          api-level: 23
+          api-level: 30
           target: google_apis
           arch: x86_64
-          script: ./gradlew connectedCheck --info | tee connectedCheck.log
+          script: |
+            ./gradlew assembleDebug assembleDebugAndroidTest
+            adb wait-for-device
+            adb shell 'while [[ $(getprop sys.boot_completed) != "1" ]]; do sleep 1; done;'
+            ./gradlew connectedCheck --info | tee connectedCheck.log
         continue-on-error: true
 
       - name: Show Test XML


### PR DESCRIPTION
<!--
    PLEASE REVIEW BEFORE OPENING
    PR guidelines:
    - Please fill out all sections where applicable!
    - PR title should be in the format <prefix>: <short description>
        - for a reminder of what prefixes are available, see here: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
    - Add your tester as a reviewer and let them know when changes are ready for them to start looking at
    - Add "N/A" under any sections that are not applicable
-->

## Description

This error was encountered during release instrumentation tests:
```
Exception thrown during onBeforeAll invocation of plugin com.google.testing.platform.plugin.android.AndroidDevicePlugin.
Failed to install APK: /home/runner/work/paypal-messages-android/paypal-messages-android/library/build/outputs/apk/androidTest/debug/library-debug-androidTest.apk, with option -r,-t
com.google.testing.platform.api.plugin.PluginException: Failed to install APK: /home/runner/work/paypal-messages-android/paypal-messages-android/library/build/outputs/apk/androidTest/debug/library-debug-androidTest.apk, with option -r,-t
```

This error indicates that the test APK (library-debug-androidTest.apk) failed to install on the Android device or emulator during the test setup (onBeforeAll) phase, using the install options -r (replace existing) and -t (allow test APKs).

Common causes include 

1. device/emulator not being ready
2. Incompatible API level
3. Corrupt or missing APK

Presumably this is an emulator setup issue. 


These issues have been addressed by 

1. assuring emulator is fully ready before install; 
2. test APK is build properly before connectedCheck; and 
3. Increased API level

<!-- Describe your changes and what problem they solve -->

## Screenshots

<!-- Add any relevant screenshots of the change or fix -->

## Testing instructions

<!--
    Include any useful information that will help with testing this change specifically, if applicable
    General testing setup can be omitted - this should focus on setup unique to this PR
-->
