### PR TITLE
feat: support language and locale params

### DIFF
--- a/demo/src/main/java/com/paypal/messagesdemo/XmlActivity.kt
+++ b/demo/src/main/java/com/paypal/messagesdemo/XmlActivity.kt
@@ -134,6 +134,8 @@ class XmlActivity : AppCompatActivity() {
 
 		val amountEdit = binding.amount
 		val buyerCountryEdit = binding.buyerCountry
+		val languageEdit = binding.language
+		val localeEdit = binding.locale
 		val stageTagEdit = binding.stageTag
 		val ignoreCache = binding.ignoreCache
 		val devTouchpoint = binding.devTouchpoint
@@ -151,6 +153,9 @@ class XmlActivity : AppCompatActivity() {
 
 			val buyerCountry = buyerCountryEdit.text.toString().ifBlank { "" }
 
+			val language = languageEdit.text.toString().ifBlank { "" }
+			val locale = localeEdit.text.toString().ifBlank { "" }
+
 			val backgroundColor = if (color === PayPalMessageColor.WHITE) Color.Black else Color.White
 			payPalMessage.setBackgroundColor(backgroundColor.hashCode())
 
@@ -158,6 +163,8 @@ class XmlActivity : AppCompatActivity() {
 			payPalMessage.clientID = clientId
 			payPalMessage.amount = amount
 			payPalMessage.buyerCountry = buyerCountry
+			payPalMessage.language = language
+			payPalMessage.locale = locale
 			payPalMessage.offerType = offerType
 			payPalMessage.environment = environment
 
@@ -177,6 +184,8 @@ class XmlActivity : AppCompatActivity() {
 			devTouchpoint.isChecked = false
 			amountEdit.setText("")
 			buyerCountryEdit.setText("")
+			languageEdit.setText("")
+			localeEdit.setText("")
 
 			updateMessageData()
 		}

--- a/demo/src/main/java/com/paypal/messagesdemo/XmlActivity.kt
+++ b/demo/src/main/java/com/paypal/messagesdemo/XmlActivity.kt
@@ -4,12 +4,15 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup.LayoutParams
+import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.graphics.Color
 import com.paypal.messages.PayPalMessageView
 import com.paypal.messages.config.PayPalEnvironment
+import com.paypal.messages.config.PayPalLanguage
+import com.paypal.messages.config.PayPalLocale
 import com.paypal.messages.config.PayPalMessageOfferType
 import com.paypal.messages.config.PayPalMessagePageType
 import com.paypal.messages.config.message.PayPalMessageConfig
@@ -134,11 +137,23 @@ class XmlActivity : AppCompatActivity() {
 
 		val amountEdit = binding.amount
 		val buyerCountryEdit = binding.buyerCountry
-		val languageEdit = binding.language
-		val localeEdit = binding.locale
+		val languageSpinner = binding.language
+		val localeSpinner = binding.locale
 		val stageTagEdit = binding.stageTag
 		val ignoreCache = binding.ignoreCache
 		val devTouchpoint = binding.devTouchpoint
+
+		// Setup language spinner
+		val languageOptions = listOf("None") + PayPalLanguage.values().map { it.name }
+		val languageAdapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, languageOptions)
+		languageAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+		languageSpinner.adapter = languageAdapter
+
+		// Setup locale spinner
+		val localeOptions = listOf("None") + PayPalLocale.values().map { it.name }
+		val localeAdapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, localeOptions)
+		localeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+		localeSpinner.adapter = localeAdapter
 
 		// Get the data from the selected options
 		fun updateMessageData() {
@@ -153,8 +168,21 @@ class XmlActivity : AppCompatActivity() {
 
 			val buyerCountry = buyerCountryEdit.text.toString().ifBlank { "" }
 
-			val language = languageEdit.text.toString().ifBlank { "" }
-			val locale = localeEdit.text.toString().ifBlank { "" }
+			// Get selected language from spinner
+			val languageSelection = languageSpinner.selectedItem.toString()
+			val language = if (languageSelection == "None") {
+				null
+			} else {
+				PayPalLanguage.valueOf(languageSelection)
+			}
+
+			// Get selected locale from spinner
+			val localeSelection = localeSpinner.selectedItem.toString()
+			val locale = if (localeSelection == "None") {
+				null
+			} else {
+				PayPalLocale.valueOf(localeSelection)
+			}
 
 			val backgroundColor = if (color === PayPalMessageColor.WHITE) Color.Black else Color.White
 			payPalMessage.setBackgroundColor(backgroundColor.hashCode())
@@ -184,8 +212,8 @@ class XmlActivity : AppCompatActivity() {
 			devTouchpoint.isChecked = false
 			amountEdit.setText("")
 			buyerCountryEdit.setText("")
-			languageEdit.setText("")
-			localeEdit.setText("")
+			languageSpinner.setSelection(0) // Reset to "None"
+			localeSpinner.setSelection(0) // Reset to "None"
 
 			updateMessageData()
 		}

--- a/demo/src/main/res/layout/activity_message.xml
+++ b/demo/src/main/res/layout/activity_message.xml
@@ -36,6 +36,50 @@
 				android:hint="Add Client ID"/>
 		</TableRow>
 
+		<TableRow
+			android:layout_width="match_parent"
+			android:layout_height="48dp">
+			<TextView
+				android:text="Language"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:id="@+id/languageLabel"
+				android:layout_weight="1"
+				android:textStyle="bold"
+				android:textSize="16sp"/>
+			<EditText
+				android:importantForAutofill="no"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:inputType="text"
+				android:ems="10"
+				android:id="@+id/language"
+				android:hint="en-US"/>
+
+		</TableRow>
+
+		<TableRow
+			android:layout_width="match_parent"
+			android:layout_height="48dp">
+			<TextView
+				android:text="Locale"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:id="@+id/localeLabel"
+				android:layout_weight="1"
+				android:textStyle="bold"
+				android:textSize="16sp"/>
+			<EditText
+				android:importantForAutofill="no"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:inputType="text"
+				android:ems="10"
+				android:id="@+id/locale"
+				android:hint="en_US"/>
+
+		</TableRow>
+
 		<TextView
 			android:text="Style Options"
 			android:layout_width="match_parent"

--- a/demo/src/main/res/layout/activity_message.xml
+++ b/demo/src/main/res/layout/activity_message.xml
@@ -47,14 +47,11 @@
 				android:layout_weight="1"
 				android:textStyle="bold"
 				android:textSize="16sp"/>
-			<EditText
-				android:importantForAutofill="no"
+			<Spinner
+				android:id="@+id/language"
 				android:layout_width="wrap_content"
 				android:layout_height="match_parent"
-				android:inputType="text"
-				android:ems="10"
-				android:id="@+id/language"
-				android:hint="en-US"/>
+				android:minWidth="200dp"/>
 
 		</TableRow>
 
@@ -69,14 +66,11 @@
 				android:layout_weight="1"
 				android:textStyle="bold"
 				android:textSize="16sp"/>
-			<EditText
-				android:importantForAutofill="no"
+			<Spinner
+				android:id="@+id/locale"
 				android:layout_width="wrap_content"
 				android:layout_height="match_parent"
-				android:inputType="text"
-				android:ems="10"
-				android:id="@+id/locale"
-				android:hint="en_US"/>
+				android:minWidth="200dp"/>
 
 		</TableRow>
 

--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -381,8 +381,8 @@ internal class ModalFragment : BottomSheetDialogFragment() {
 		this.devTouchpoint = config.devTouchpoint
 		this.ignoreCache = config.ignoreCache
 		this.offerType = config.offer
-		this.language = config.language
-		this.locale = config.locale
+		this.language = config.language?.code
+		this.locale = config.locale?.code
 		this.stageTag = config.stageTag
 
 		// Set Callbacks for Modal Actions

--- a/library/src/main/java/com/paypal/messages/ModalFragment.kt
+++ b/library/src/main/java/com/paypal/messages/ModalFragment.kt
@@ -106,6 +106,8 @@ internal class ModalFragment : BottomSheetDialogFragment() {
 				setJsValue(name = "offer", value = offerArg.toString())
 			}
 		}
+	var language: String? = null
+	var locale: String? = null
 	private var stageTag: String? = null
 
 	private var inErrorState: Boolean = false
@@ -268,7 +270,7 @@ internal class ModalFragment : BottomSheetDialogFragment() {
 	 * Loads or reloads the URL for the modal
 	 */
 	private fun reloadUrl() {
-		val url = Api.createModalUrl(clientId, amount, buyerCountry, offerType)
+		val url = Api.createModalUrl(clientId, amount, buyerCountry, offerType, language, locale)
 		LogCat.debug(TAG, "Loading modal URL: $url")
 		modalUrl = url
 		webView?.loadUrl(url)
@@ -379,6 +381,8 @@ internal class ModalFragment : BottomSheetDialogFragment() {
 		this.devTouchpoint = config.devTouchpoint
 		this.ignoreCache = config.ignoreCache
 		this.offerType = config.offer
+		this.language = config.language
+		this.locale = config.locale
 		this.stageTag = config.stageTag
 
 		// Set Callbacks for Modal Actions
@@ -452,7 +456,7 @@ internal class ModalFragment : BottomSheetDialogFragment() {
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		logEvent(AnalyticsEvent(eventType = EventType.MODAL_VIEWED))
 		this.onLoading()
-		val url = Api.createModalUrl(clientId, amount, buyerCountry, offerType)
+		val url = Api.createModalUrl(clientId, amount, buyerCountry, offerType, language, locale)
 
 		LogCat.debug(TAG, "Start show process for modal with webView: $webView")
 		val requestDuration = measureTimeMillis {

--- a/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
+++ b/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
@@ -24,6 +24,8 @@ import com.paypal.messages.analytics.AnalyticsLogger
 import com.paypal.messages.analytics.ComponentType
 import com.paypal.messages.analytics.EventType
 import com.paypal.messages.config.PayPalEnvironment
+import com.paypal.messages.config.PayPalLanguage
+import com.paypal.messages.config.PayPalLocale
 import com.paypal.messages.config.ProductGroup
 import com.paypal.messages.data.PayPalMessageDataCallback
 import com.paypal.messages.data.PayPalMessageDataProvider
@@ -176,14 +178,14 @@ class PayPalMessageView @JvmOverloads constructor(
 				debounceUpdateContent(Unit)
 			}
 		}
-	var language: String? = config.data.language
+	var language: PayPalLanguage? = config.data.language
 		set(arg) {
 			if (field != arg) {
 				field = arg
 				debounceUpdateContent(Unit)
 			}
 		}
-	var locale: String? = config.data.locale
+	var locale: PayPalLocale? = config.data.locale
 		set(arg) {
 			if (field != arg) {
 				field = arg
@@ -653,8 +655,8 @@ class PayPalMessageView @JvmOverloads constructor(
 			amount = this.amount.toString(),
 			pageType = this.pageType,
 			buyerCountryCode = this.buyerCountry,
-			language = this.language,
-			locale = this.locale,
+			language = this.language?.code,
+			locale = this.locale?.code,
 			styleLogoType = this.logoType,
 			styleColor = this.color,
 			styleTextAlign = this.textAlignment,

--- a/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
+++ b/library/src/main/java/com/paypal/messages/PayPalMessageView.kt
@@ -87,6 +87,8 @@ class PayPalMessageView @JvmOverloads constructor(
 				buyerCountry = this.buyerCountry,
 				offerType = this.offerType,
 				pageType = this.pageType,
+				language = this.language,
+				locale = this.locale,
 				environment = this.environment ?: PayPalEnvironment.SANDBOX,
 			),
 			style = MessageStyle(this.color, this.logoType, this.textAlignment),
@@ -103,6 +105,8 @@ class PayPalMessageView @JvmOverloads constructor(
 		buyerCountry = config.data.buyerCountry
 		offerType = config.data.offerType
 		pageType = config.data.pageType
+		language = config.data.language
+		locale = config.data.locale
 		color = config.style.color
 		logoType = config.style.logoType
 		textAlignment = config.style.textAlignment
@@ -166,6 +170,20 @@ class PayPalMessageView @JvmOverloads constructor(
 			}
 		}
 	var buyerCountry: String? = config.data.buyerCountry
+		set(arg) {
+			if (field != arg) {
+				field = arg
+				debounceUpdateContent(Unit)
+			}
+		}
+	var language: String? = config.data.language
+		set(arg) {
+			if (field != arg) {
+				field = arg
+				debounceUpdateContent(Unit)
+			}
+		}
+	var locale: String? = config.data.locale
 		set(arg) {
 			if (field != arg) {
 				field = arg
@@ -635,6 +653,8 @@ class PayPalMessageView @JvmOverloads constructor(
 			amount = this.amount.toString(),
 			pageType = this.pageType,
 			buyerCountryCode = this.buyerCountry,
+			language = this.language,
+			locale = this.locale,
 			styleLogoType = this.logoType,
 			styleColor = this.color,
 			styleTextAlign = this.textAlignment,

--- a/library/src/main/java/com/paypal/messages/analytics/AnalyticsComponent.kt
+++ b/library/src/main/java/com/paypal/messages/analytics/AnalyticsComponent.kt
@@ -30,6 +30,10 @@ data class AnalyticsComponent(
 	val pageType: PayPalMessagePageType? = null,
 	@SerializedName("buyer_country_code")
 	val buyerCountryCode: String? = null,
+	@SerializedName("language")
+	val language: String? = null,
+	@SerializedName("locale")
+	val locale: String? = null,
 	@SerializedName("presentment_channel")
 	val channel: String? = "UPSTREAM",
 

--- a/library/src/main/java/com/paypal/messages/config/PayPalLanguage.kt
+++ b/library/src/main/java/com/paypal/messages/config/PayPalLanguage.kt
@@ -1,0 +1,28 @@
+package com.paypal.messages.config
+
+/**
+ * Enum representing supported PayPal languages
+ * @property code The language code (e.g., "en-US", "es-ES", "fr-FR")
+ */
+enum class PayPalLanguage(val code: String) {
+	US_ENGLISH("en-US"),
+	GB_ENGLISH("en-GB"),
+	AUSTRALIA_ENGLISH("en-AU"),
+	CANADA_ENGLISH("en-CA"),
+	CANADA_FRENCH("fr-CA"),
+	SPAIN("es-ES"),
+	FRANCE("fr-FR"),
+	GERMANY("de-DE"),
+	AUSTRIA("de-AT"),
+	ITALY("it-IT"),
+	;
+
+	companion object {
+		/**
+		 * Get PayPalLanguage from a string code. Returns null if not found.
+		 */
+		fun fromCode(code: String?): PayPalLanguage? {
+			return values().find { it.code.equals(code, ignoreCase = true) }
+		}
+	}
+}

--- a/library/src/main/java/com/paypal/messages/config/PayPalLocale.kt
+++ b/library/src/main/java/com/paypal/messages/config/PayPalLocale.kt
@@ -1,0 +1,28 @@
+package com.paypal.messages.config
+
+/**
+ * Enum representing supported PayPal locales
+ * @property code The locale code (e.g., "en_US", "es_ES", "fr_FR")
+ */
+enum class PayPalLocale(val code: String) {
+	US_ENGLISH("en_US"),
+	GB_ENGLISH("en_GB"),
+	AUSTRALIA_ENGLISH("en_AU"),
+	CANADA_ENGLISH("en_CA"),
+	CANADA_FRENCH("fr_CA"),
+	SPAIN("es_ES"),
+	FRANCE("fr_FR"),
+	GERMANY("de_DE"),
+	AUSTRIA("de_AT"),
+	ITALY("it_IT"),
+	;
+
+	companion object {
+		/**
+		 * Get PayPalLocale from a string code. Returns null if not found.
+		 */
+		fun fromCode(code: String?): PayPalLocale? {
+			return values().find { it.code.equals(code, ignoreCase = true) }
+		}
+	}
+}

--- a/library/src/main/java/com/paypal/messages/config/message/PayPalMessageData.kt
+++ b/library/src/main/java/com/paypal/messages/config/message/PayPalMessageData.kt
@@ -18,6 +18,8 @@ data class PayPalMessageData(
 	var buyerCountry: String? = null,
 	var offerType: OfferType? = null,
 	var pageType: PageType? = null,
+	var language: String? = null,
+	var locale: String? = null,
 	var environment: Environment = Environment.SANDBOX,
 ) : Cloneable {
 	init {

--- a/library/src/main/java/com/paypal/messages/config/message/PayPalMessageData.kt
+++ b/library/src/main/java/com/paypal/messages/config/message/PayPalMessageData.kt
@@ -1,5 +1,7 @@
 package com.paypal.messages.config.message
 
+import com.paypal.messages.config.PayPalLanguage
+import com.paypal.messages.config.PayPalLocale
 import com.paypal.messages.io.Api
 import com.paypal.messages.config.PayPalEnvironment as Environment
 import com.paypal.messages.config.PayPalMessageOfferType as OfferType
@@ -18,8 +20,8 @@ data class PayPalMessageData(
 	var buyerCountry: String? = null,
 	var offerType: OfferType? = null,
 	var pageType: PageType? = null,
-	var language: String? = null,
-	var locale: String? = null,
+	var language: PayPalLanguage? = null,
+	var locale: PayPalLocale? = null,
 	var environment: Environment = Environment.SANDBOX,
 ) : Cloneable {
 	init {

--- a/library/src/main/java/com/paypal/messages/config/modal/ModalConfig.kt
+++ b/library/src/main/java/com/paypal/messages/config/modal/ModalConfig.kt
@@ -1,6 +1,8 @@
 package com.paypal.messages.config.modal
 
 import com.paypal.messages.config.Channel
+import com.paypal.messages.config.PayPalLanguage
+import com.paypal.messages.config.PayPalLocale
 import com.paypal.messages.config.PayPalMessageOfferType
 
 /**
@@ -16,7 +18,7 @@ data class ModalConfig(
 	var ignoreCache: Boolean = false,
 	var modalCloseButton: ModalCloseButton,
 	var offer: PayPalMessageOfferType? = null,
-	var language: String? = null,
-	var locale: String? = null,
+	var language: PayPalLanguage? = null,
+	var locale: PayPalLocale? = null,
 	var stageTag: String? = null,
 )

--- a/library/src/main/java/com/paypal/messages/config/modal/ModalConfig.kt
+++ b/library/src/main/java/com/paypal/messages/config/modal/ModalConfig.kt
@@ -16,5 +16,7 @@ data class ModalConfig(
 	var ignoreCache: Boolean = false,
 	var modalCloseButton: ModalCloseButton,
 	var offer: PayPalMessageOfferType? = null,
+	var language: String? = null,
+	var locale: String? = null,
 	var stageTag: String? = null,
 )

--- a/library/src/main/java/com/paypal/messages/data/PayPalMessageDataProvider.kt
+++ b/library/src/main/java/com/paypal/messages/data/PayPalMessageDataProvider.kt
@@ -349,6 +349,8 @@ class PayPalMessageDataProvider {
 						ignoreCache = false,
 						devTouchpoint = false,
 						stageTag = null,
+						language = config.data.language,
+						locale = config.data.locale,
 						events = ModalEvents(
 							onApply = onApply,
 							// onClick is already called before this method is invoked - don't call it again

--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -59,8 +59,8 @@ object Api {
 			amount?.let { addQueryParameter("amount", it.toString()) }
 			if (!buyerCountry.isNullOrBlank()) addQueryParameter("buyer_country", buyerCountry)
 			offerType?.let { addQueryParameter("offer", it.name) }
-			if (!language.isNullOrBlank()) addQueryParameter("language", language)
-			if (!locale.isNullOrBlank()) addQueryParameter("locale", locale)
+			language?.let { addQueryParameter("language", it.code) }
+			locale?.let { addQueryParameter("locale", it.code) }
 		}
 
 		if (!hash.isNullOrBlank()) addQueryParameter("merchant_config", hash)

--- a/library/src/main/java/com/paypal/messages/io/Api.kt
+++ b/library/src/main/java/com/paypal/messages/io/Api.kt
@@ -59,6 +59,8 @@ object Api {
 			amount?.let { addQueryParameter("amount", it.toString()) }
 			if (!buyerCountry.isNullOrBlank()) addQueryParameter("buyer_country", buyerCountry)
 			offerType?.let { addQueryParameter("offer", it.name) }
+			if (!language.isNullOrBlank()) addQueryParameter("language", language)
+			if (!locale.isNullOrBlank()) addQueryParameter("locale", locale)
 		}
 
 		if (!hash.isNullOrBlank()) addQueryParameter("merchant_config", hash)
@@ -214,6 +216,8 @@ object Api {
 		amount: Double?,
 		buyerCountry: String?,
 		offer: OfferType?,
+		language: String? = null,
+		locale: String? = null,
 	): String {
 		val url = env.url(Env.Endpoints.MODAL_DATA).newBuilder().apply {
 			addQueryParameter("client_id", clientId)
@@ -222,6 +226,8 @@ object Api {
 			amount?.let { addQueryParameter("amount", amount.toString()) }
 			if (!buyerCountry.isNullOrBlank()) addQueryParameter("buyer_country", buyerCountry)
 			offer?.let { addQueryParameter("offer", it.name) }
+			if (!language.isNullOrBlank()) addQueryParameter("language", language)
+			if (!locale.isNullOrBlank()) addQueryParameter("locale", locale)
 		}.build()
 
 		val query = url.query?.replace("&", "\n  ")

--- a/library/src/test/java/com/paypal/messages/config/PayPalLanguageTest.kt
+++ b/library/src/test/java/com/paypal/messages/config/PayPalLanguageTest.kt
@@ -1,0 +1,85 @@
+package com.paypal.messages.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PayPalLanguage enum
+ */
+class PayPalLanguageTest {
+
+	@Test
+	fun testEnumProperties() {
+		// Test a few representative enum values to verify structure
+		assertEquals("en-US", PayPalLanguage.US_ENGLISH.code)
+		assertEquals("fr-FR", PayPalLanguage.FRANCE.code)
+		assertEquals("de-DE", PayPalLanguage.GERMANY.code)
+	}
+
+	@Test
+	fun testLanguageValues() {
+		// Test that enum values can be retrieved
+		val values = PayPalLanguage.values()
+		
+		assertNotNull(values)
+		assertEquals(10, values.size)
+		assertEquals(PayPalLanguage.US_ENGLISH, values[0])
+		assertEquals(PayPalLanguage.GB_ENGLISH, values[1])
+		assertEquals(PayPalLanguage.AUSTRALIA_ENGLISH, values[2])
+		assertEquals(PayPalLanguage.CANADA_ENGLISH, values[3])
+		assertEquals(PayPalLanguage.CANADA_FRENCH, values[4])
+		assertEquals(PayPalLanguage.SPAIN, values[5])
+		assertEquals(PayPalLanguage.FRANCE, values[6])
+		assertEquals(PayPalLanguage.GERMANY, values[7])
+		assertEquals(PayPalLanguage.AUSTRIA, values[8])
+		assertEquals(PayPalLanguage.ITALY, values[9])
+	}
+
+	@Test
+	fun testLanguageValueOf() {
+		// Test that valueOf works correctly
+		assertEquals(PayPalLanguage.US_ENGLISH, PayPalLanguage.valueOf("US_ENGLISH"))
+		assertEquals(PayPalLanguage.FRANCE, PayPalLanguage.valueOf("FRANCE"))
+	}
+
+	@Test
+	fun testFromCodeValidCodes() {
+		// Test fromCode with exact matches
+		assertEquals(PayPalLanguage.US_ENGLISH, PayPalLanguage.fromCode("en-US"))
+		assertEquals(PayPalLanguage.GB_ENGLISH, PayPalLanguage.fromCode("en-GB"))
+		assertEquals(PayPalLanguage.AUSTRALIA_ENGLISH, PayPalLanguage.fromCode("en-AU"))
+		assertEquals(PayPalLanguage.CANADA_ENGLISH, PayPalLanguage.fromCode("en-CA"))
+		assertEquals(PayPalLanguage.CANADA_FRENCH, PayPalLanguage.fromCode("fr-CA"))
+		assertEquals(PayPalLanguage.SPAIN, PayPalLanguage.fromCode("es-ES"))
+		assertEquals(PayPalLanguage.FRANCE, PayPalLanguage.fromCode("fr-FR"))
+		assertEquals(PayPalLanguage.GERMANY, PayPalLanguage.fromCode("de-DE"))
+		assertEquals(PayPalLanguage.AUSTRIA, PayPalLanguage.fromCode("de-AT"))
+		assertEquals(PayPalLanguage.ITALY, PayPalLanguage.fromCode("it-IT"))
+	}
+
+	@Test
+	fun testFromCodeCaseInsensitive() {
+		// Test that fromCode is case-insensitive
+		assertEquals(PayPalLanguage.US_ENGLISH, PayPalLanguage.fromCode("EN-US"))
+		assertEquals(PayPalLanguage.GB_ENGLISH, PayPalLanguage.fromCode("en-gb"))
+		assertEquals(PayPalLanguage.FRANCE, PayPalLanguage.fromCode("FR-fr"))
+		assertEquals(PayPalLanguage.GERMANY, PayPalLanguage.fromCode("DE-de"))
+	}
+
+	@Test
+	fun testFromCodeInvalidCode() {
+		// Test that fromCode returns null for invalid codes
+		assertNull(PayPalLanguage.fromCode("invalid"))
+		assertNull(PayPalLanguage.fromCode("en"))
+		assertNull(PayPalLanguage.fromCode("fr-BE"))
+		assertNull(PayPalLanguage.fromCode(""))
+	}
+
+	@Test
+	fun testFromCodeNull() {
+		// Test that fromCode handles null input
+		assertNull(PayPalLanguage.fromCode(null))
+	}
+}

--- a/library/src/test/java/com/paypal/messages/config/PayPalLocaleTest.kt
+++ b/library/src/test/java/com/paypal/messages/config/PayPalLocaleTest.kt
@@ -1,0 +1,85 @@
+package com.paypal.messages.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for PayPalLocale enum
+ */
+class PayPalLocaleTest {
+
+	@Test
+	fun testEnumProperties() {
+		// Test a few representative enum values to verify structure
+		assertEquals("en_US", PayPalLocale.US_ENGLISH.code)
+		assertEquals("fr_FR", PayPalLocale.FRANCE.code)
+		assertEquals("de_DE", PayPalLocale.GERMANY.code)
+	}
+
+	@Test
+	fun testLocaleValues() {
+		// Test that enum values can be retrieved
+		val values = PayPalLocale.values()
+		
+		assertNotNull(values)
+		assertEquals(10, values.size)
+		assertEquals(PayPalLocale.US_ENGLISH, values[0])
+		assertEquals(PayPalLocale.GB_ENGLISH, values[1])
+		assertEquals(PayPalLocale.AUSTRALIA_ENGLISH, values[2])
+		assertEquals(PayPalLocale.CANADA_ENGLISH, values[3])
+		assertEquals(PayPalLocale.CANADA_FRENCH, values[4])
+		assertEquals(PayPalLocale.SPAIN, values[5])
+		assertEquals(PayPalLocale.FRANCE, values[6])
+		assertEquals(PayPalLocale.GERMANY, values[7])
+		assertEquals(PayPalLocale.AUSTRIA, values[8])
+		assertEquals(PayPalLocale.ITALY, values[9])
+	}
+
+	@Test
+	fun testLocaleValueOf() {
+		// Test that valueOf works correctly
+		assertEquals(PayPalLocale.US_ENGLISH, PayPalLocale.valueOf("US_ENGLISH"))
+		assertEquals(PayPalLocale.FRANCE, PayPalLocale.valueOf("FRANCE"))
+	}
+
+	@Test
+	fun testFromCodeValidCodes() {
+		// Test fromCode with exact matches
+		assertEquals(PayPalLocale.US_ENGLISH, PayPalLocale.fromCode("en_US"))
+		assertEquals(PayPalLocale.GB_ENGLISH, PayPalLocale.fromCode("en_GB"))
+		assertEquals(PayPalLocale.AUSTRALIA_ENGLISH, PayPalLocale.fromCode("en_AU"))
+		assertEquals(PayPalLocale.CANADA_ENGLISH, PayPalLocale.fromCode("en_CA"))
+		assertEquals(PayPalLocale.CANADA_FRENCH, PayPalLocale.fromCode("fr_CA"))
+		assertEquals(PayPalLocale.SPAIN, PayPalLocale.fromCode("es_ES"))
+		assertEquals(PayPalLocale.FRANCE, PayPalLocale.fromCode("fr_FR"))
+		assertEquals(PayPalLocale.GERMANY, PayPalLocale.fromCode("de_DE"))
+		assertEquals(PayPalLocale.AUSTRIA, PayPalLocale.fromCode("de_AT"))
+		assertEquals(PayPalLocale.ITALY, PayPalLocale.fromCode("it_IT"))
+	}
+
+	@Test
+	fun testFromCodeCaseInsensitive() {
+		// Test that fromCode is case-insensitive
+		assertEquals(PayPalLocale.US_ENGLISH, PayPalLocale.fromCode("EN_US"))
+		assertEquals(PayPalLocale.GB_ENGLISH, PayPalLocale.fromCode("en_gb"))
+		assertEquals(PayPalLocale.FRANCE, PayPalLocale.fromCode("FR_fr"))
+		assertEquals(PayPalLocale.GERMANY, PayPalLocale.fromCode("DE_de"))
+	}
+
+	@Test
+	fun testFromCodeInvalidCode() {
+		// Test that fromCode returns null for invalid codes
+		assertNull(PayPalLocale.fromCode("invalid"))
+		assertNull(PayPalLocale.fromCode("en"))
+		assertNull(PayPalLocale.fromCode("fr_BE"))
+		assertNull(PayPalLocale.fromCode(""))
+	}
+
+	@Test
+	fun testFromCodeNull() {
+		// Test that fromCode handles null input
+		assertNull(PayPalLocale.fromCode(null))
+	}
+}


### PR DESCRIPTION
## Description
add support for language and locale params for localized content

## Screenshots
N/A

## Testing instructions
language uses hyphenated format, e.g. fr-CA
locale uses underscore format, e.g. fr_CA