### PR TITLE
docs: add Braintree SDK requirement disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A messaging component library allowing easy integration of PayPal Credit Messages onto your app.
 
+> **Note:** This messaging component is intended for use with the **[Braintree SDK](https://developer.paypal.com/braintree/docs/guides/paypal/messaging/android/v5)** only. To integrate PayPal messaging in your Android app, you must have a Braintree account and the Braintree SDK integrated. PPCP SDK integrations are not supported.
+
 - [Availability](#availability)
 - [Contribution](#contribution)
 - [Support](#support)


### PR DESCRIPTION
## Summary
- Adds a note at the top of the README clarifying that this library is intended for use with the Braintree SDK only
- Merchants must have a Braintree account and the Braintree SDK integrated
- PPCP SDK integrations are not supported
- Links to the [Braintree Android messaging docs](https://developer.paypal.com/braintree/docs/guides/paypal/messaging/android/v5)

Addresses merchant/SE confusion around PPCP SDK compatibility.